### PR TITLE
deactivates UIScrollView.scrollsToTop behavior

### DIFF
--- a/Classes/InfinitePagingView.m
+++ b/Classes/InfinitePagingView.m
@@ -58,6 +58,7 @@
         _innerScrollView.scrollEnabled = YES;
         _innerScrollView.showsHorizontalScrollIndicator = NO;
         _innerScrollView.showsVerticalScrollIndicator = NO;
+				_innerScrollView.scrollsToTop = NO;
         _scrollDirection = InfinitePagingViewHorizonScrollDirection;
         [self addSubview:_innerScrollView];
         self.pageSize = frame.size;


### PR DESCRIPTION
Deactivated the scrollsToTop behavior to fix a problem, that occurred while the InfinitePagingView is a subview of another UIScrollView
