### PR TITLE
noxytrux-IPV-1 fix for crash while deallocating view

### DIFF
--- a/Classes/InfinitePagingView.m
+++ b/Classes/InfinitePagingView.m
@@ -65,6 +65,16 @@
     }
 }
 
+- (void)dealloc
+{
+    /**
+        nil delegate in ARC to prevent Core Animation Retain which lead to crash if view
+        that use InfinitePagingView deallocates while animating to next page.
+     */
+    
+    _innerScrollView.delegate = nil;
+}
+
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     UIView *hitView = [super hitTest:point withEvent:event];


### PR DESCRIPTION
Hi, some usefull trick to make your code safe while some deallocation appear. This acutally case to crash in my app so let's save hours of debugging to other people :)

Backtrace of crash: (this lead to nowhere so may be quiet hard to debug for some people)

Thread : Crashed: com.apple.main-thread
0  libobjc.A.dylib                0x349ddf66 objc_msgSend + 5
1  UIKit                          0x2a45fd69 -[UIScrollView(UIScrollViewInternal) _notifyDidScroll] + 64
2  UIKit                          0x2a1d1d51 -[UIScrollView setContentOffset:] + 628
3  UIKit                          0x2a353649 -[UIAnimator(Static) _advanceAnimationsOfType:withTimestamp:] + 272
4  UIKit                          0x2a353535 -[UIAnimator(Static) _LCDHeartbeatCallback:] + 52
5  QuartzCore                     0x29c2c94b CA::Display::DisplayLinkItem::dispatch() + 98
6  QuartzCore                     0x29c2c7b3 CA::Display::DisplayLink::dispatch_items(unsigned long long, unsigned long long, unsigned long long) + 366
7  IOMobileFramebuffer            0x2e6f282f IOMobileFramebufferVsyncNotifyFunc + 90
8  IOKit                          0x27c24d7d IODispatchCalloutFromCFMessage + 256